### PR TITLE
Fix deprecation warning in nightly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ license = "Apache-2.0"
 maintenance = {status = "actively-developed,experimental"}
 
 [dependencies]
+dirs = "1.0"
 url = "1.6"
 hyper = "0.12"
 hyper-tls = "0.3"

--- a/examples/client-watch.rs
+++ b/examples/client-watch.rs
@@ -98,7 +98,7 @@ fn main() {
         Ok(_) => 0,
         Err(e) => {
             eprintln!("Error: {}", e);
-            for c in e.causes().skip(1) {
+            for c in e.iter_chain().skip(1) {
                 eprintln!(" Caused by {}", c);
             }
             debug!("Backtrace: {}", e.backtrace());

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -47,7 +47,7 @@ fn main() {
         Ok(_) => 0,
         Err(e) => {
             eprintln!("Error: {}", e);
-            for c in e.causes().skip(1) {
+            for c in e.iter_chain().skip(1) {
                 eprintln!(" Caused by {}", c);
             }
             eprintln!("{}", e.backtrace());

--- a/src/client/config/mod.rs
+++ b/src/client/config/mod.rs
@@ -1,6 +1,6 @@
+extern crate dirs;
 use std::path::{Path,PathBuf};
 use std::fs::File;
-use std::env::home_dir;
 use std::io::{self,Read};
 use failure::Error;
 use serde_yaml;
@@ -20,7 +20,7 @@ pub fn config_err(msg: &'static str) -> ConfigError {
 }
 
 pub fn default_path() -> Option<PathBuf> {
-    home_dir()
+    dirs::home_dir()
         .map(|h| h.join(".kube").join("config"))
 }
 


### PR DESCRIPTION
Apparently home_dir isn't what one thinks it is.