### PR TITLE
 #19: Add the ContainersReady pod status

### DIFF
--- a/holding/src/api/core/v1.rs
+++ b/holding/src/api/core/v1.rs
@@ -747,9 +747,10 @@ pub struct PodStatus {
 
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq)]
 pub enum PodConditionType {
+    ContainersReady,
+    Initialized,
     PodScheduled,
     Ready,
-    Initialized,
     Unschedulable,
 }
 


### PR DESCRIPTION
This is really only part of the work needed.

Due to the 1.11 ReadinessGate feature (
    https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-readiness-gate
) PodStatus is no longer strictly definable, as it can be of arbitrary
length and contents.