### PR TITLE
Add Resource / NamespacedResource to bind GVR to Kind

### DIFF
--- a/api/src/core/v1.rs
+++ b/api/src/core/v1.rs
@@ -1,5 +1,5 @@
-use crate::meta::v1::{ItemList, LabelSelector, Metadata, ObjectMeta};
-use crate::meta::GroupVersion;
+use crate::meta::v1::{ItemList, LabelSelector, List, Metadata, ObjectMeta};
+use crate::meta::{GroupVersion, GroupVersionResource};
 use crate::{IntOrString, Integer, Quantity, Time, TypeMeta, TypeMetaImpl};
 use serde_json::{self, Map, Value};
 use std::borrow::Cow;
@@ -12,6 +12,32 @@ pub const GROUP_VERSION: GroupVersion = GroupVersion {
     group: "",
     version: "v1",
 };
+
+pub struct Pods;
+
+pub trait NamespacedResource {
+    type List: List;
+
+    fn gvr(&self) -> GroupVersionResource;
+}
+
+pub trait Resource {
+    type List: List;
+
+    fn gvr(&self) -> GroupVersionResource;
+}
+
+impl NamespacedResource for Pods {
+    type List = PodList;
+
+    fn gvr(&self) -> GroupVersionResource {
+        GroupVersionResource {
+            group: "",
+            version: "v1",
+            resource: "pods",
+        }
+    }
+}
 
 #[derive(Serialize, Deserialize, Default, Debug, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]

--- a/api/src/meta/v1.rs
+++ b/api/src/meta/v1.rs
@@ -307,20 +307,22 @@ where
     }
 }
 
-impl<T> List<T> for ItemList<T>
+impl<T> List for ItemList<T>
 where
     T: TypeMeta,
 {
+    type Item = T;
+
     fn listmeta(&self) -> Cow<ListMeta> {
         Cow::Borrowed(&self.metadata)
     }
-    fn items(&self) -> &[T] {
+    fn items(&self) -> &[Self::Item] {
         &self.items
     }
-    fn items_mut(&mut self) -> &mut [T] {
+    fn items_mut(&mut self) -> &mut [Self::Item] {
         &mut self.items
     }
-    fn into_items(self) -> Vec<T> {
+    fn into_items(self) -> Vec<Self::Item> {
         self.items
     }
 }
@@ -395,14 +397,15 @@ pub trait Metadata {
     fn metadata(&self) -> Cow<ObjectMeta>;
 }
 
-pub trait List<T> {
+pub trait List {
+    type Item;
     fn listmeta(&self) -> Cow<ListMeta>;
-    fn items(&self) -> &[T];
-    fn items_mut(&mut self) -> &mut [T];
-    fn into_items(self) -> Vec<T>;
+    fn items(&self) -> &[Self::Item];
+    fn items_mut(&mut self) -> &mut [Self::Item];
+    fn into_items(self) -> Vec<Self::Item>;
 }
 
-impl<'a, T> IntoIterator for &'a List<T> {
+impl<'a, T> IntoIterator for &'a List<Item = T> {
     type Item = &'a T;
     type IntoIter = slice::Iter<'a, T>;
 
@@ -411,7 +414,7 @@ impl<'a, T> IntoIterator for &'a List<T> {
     }
 }
 
-impl<'a, T> IntoIterator for &'a mut List<T> {
+impl<'a, T> IntoIterator for &'a mut List<Item = T> {
     type Item = &'a mut T;
     type IntoIter = slice::IterMut<'a, T>;
 

--- a/api/src/unstructured.rs
+++ b/api/src/unstructured.rs
@@ -16,7 +16,9 @@ impl Metadata for Value {
     }
 }
 
-impl List<Value> for Value {
+impl List for Value {
+    type Item = Value;
+
     fn listmeta(&self) -> Cow<ListMeta> {
         serde_json::from_value(self["metadata"].clone()).unwrap_or_default()
     }

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -14,30 +14,38 @@ use futures::prelude::*;
 use std::result::Result;
 use tokio::runtime::current_thread;
 
-use kubernetes_api::core::v1::Pod;
+use kubernetes_api::core::v1::Pods;
 use kubernetes_api::meta::v1::ListOptions;
 use kubernetes_holding::client::Client;
 
 fn main_() -> Result<(), Error> {
     let client = Client::new()?;
 
-    let pods = kubernetes_api::core::v1::GROUP_VERSION.with_resource("pods");
-    let namespace = Some("kube-system");
+    let namespace = "kube-system";
+
+    let nsclient = client.namespace(namespace);
+
+    let names_future = nsclient
+        .iter(Pods {})
+        .map(|pod| pod.metadata.name.unwrap())
+        .collect();
 
     // Artificially low `limit`, to demonstrate pagination
     let opts = ListOptions {
         limit: 2,
         ..Default::default()
     };
-
-    let names_future = client
-        .iter::<Pod>(&pods, namespace, opts)
-        .map(|pod| pod.metadata.name.unwrap_or("(no name)".into()))
+    let names_future2 = nsclient
+        .iter_opt(Pods {}, opts)
+        .map(|pod| pod.metadata.name.unwrap())
         .collect();
 
     // Resolve future synchronously, for simpler demo
     let mut rt = current_thread::Runtime::new()?;
     let names = rt.block_on(names_future)?;
+    let names2 = rt.block_on(names_future2)?;
+
+    assert_eq!(names, names2);
 
     for n in names {
         println!("Found name: {}", n);


### PR DESCRIPTION
Split namespaced / non-namespaced client methods, based on flavour of
Resource trait.

`iter()` only for now - rest will follow.

Co-authored with Robert Collins