### PR TITLE
Extend NamespaceResource to include non-namespaced

### DIFF
--- a/api/src/core/v1.rs
+++ b/api/src/core/v1.rs
@@ -46,6 +46,91 @@ impl NamespacedResource for Pods {
 
 #[derive(Serialize, Deserialize, Default, Debug, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
+pub struct Namespace {
+    #[serde(flatten)]
+    typemeta: TypeMetaImpl<Pod>,
+    #[serde(default)]
+    pub metadata: ObjectMeta,
+    #[serde(default)]
+    pub spec: NamespaceSpec,
+    #[serde(default)]
+    pub status: NamespaceStatus,
+}
+
+impl NamespacedResource for Namespace {
+    type List = NamespaceList;
+
+    fn namespaced(&self) -> bool {
+        false
+    }
+
+    fn gvr(&self) -> GroupVersionResource {
+        GroupVersionResource {
+            group: "",
+            version: "v1",
+            resource: "namespaces",
+        }
+    }
+}
+
+impl Resource for Namespace {
+    type List = NamespaceList;
+
+    fn gvr(&self) -> GroupVersionResource {
+        GroupVersionResource {
+            group: "",
+            version: "v1",
+            resource: "namespaces",
+        }
+    }
+}
+
+pub type NamespaceList = ItemList<Namespace>;
+
+impl TypeMeta for Namespace {
+    fn api_version() -> &'static str {
+        API_GROUP
+    }
+    fn kind() -> &'static str {
+        "Namespace"
+    }
+}
+
+impl Metadata for Namespace {
+    fn api_version(&self) -> &str {
+        <Namespace as TypeMeta>::api_version()
+    }
+    fn kind(&self) -> &str {
+        <Namespace as TypeMeta>::kind()
+    }
+    fn metadata(&self) -> Cow<ObjectMeta> {
+        Cow::Borrowed(&self.metadata)
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct NamespaceSpec {
+    #[serde(default)]
+    pub finalizers: Vec<String>,
+}
+
+const FINALIZER_KUBERNETES: &str = "kubernetes";
+
+#[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct NamespaceStatus {
+    pub phase: Option<NamespacePhase>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq)]
+pub enum NamespacePhase {
+    Active,
+    Terminating,
+}
+
+#[derive(Serialize, Deserialize, Default, Debug, Clone, PartialEq)]
+#[serde(rename_all = "camelCase")]
 pub struct Pod {
     #[serde(flatten)]
     typemeta: TypeMetaImpl<Pod>,

--- a/api/src/core/v1.rs
+++ b/api/src/core/v1.rs
@@ -19,6 +19,7 @@ pub trait NamespacedResource {
     type List: List;
 
     fn gvr(&self) -> GroupVersionResource;
+    fn namespaced(&self) -> bool;
 }
 
 pub trait Resource {
@@ -29,6 +30,10 @@ pub trait Resource {
 
 impl NamespacedResource for Pods {
     type List = PodList;
+
+    fn namespaced(&self) -> bool {
+        true
+    }
 
     fn gvr(&self) -> GroupVersionResource {
         GroupVersionResource {

--- a/holding/src/client/mod.rs
+++ b/holding/src/client/mod.rs
@@ -272,8 +272,12 @@ impl<'a, C: hyper::client::connect::Connect + 'static> NamespacedClient<'a, C> {
         T::List: List + DeserializeOwned + Send + 'static,
         <T::List as List>::Item: TypeMeta + DeserializeOwned + Default + Send + 'static,
     {
-        self.client
-            ._do_iter::<T::List>(rsrc.gvr(), Some(self.namespace), opts)
+        let ns = if rsrc.namespaced() {
+            Some(self.namespace)
+        } else {
+            None
+        };
+        self.client._do_iter::<T::List>(rsrc.gvr(), ns, opts)
     }
 }
 


### PR DESCRIPTION
- Make NamespaceResource also cover non-namespaced, by just ignoring the namespace
- Add Namespace kind and resource, as an example of non-namespaced resource

Co-authored with Robert Collins